### PR TITLE
ci: add semantic PR title validation workflow

### DIFF
--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,0 +1,19 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to enforce conventional commit format on PR titles
- Copied from `bout-api` repo — uses `amannn/action-semantic-pull-request@v5`

## Test plan
- [ ] Open a PR with a non-conventional title and verify it fails
- [ ] Open a PR with a conventional title (e.g., `feat: ...`) and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)