### PR TITLE
feat: add tclaude-kill for session cleanup

### DIFF
--- a/bin/tclaude-kill
+++ b/bin/tclaude-kill
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# tclaude-kill - Kill tmux sessions by name or interactively
+# Supports: tclaude-kill <name>, tclaude-kill --all, tclaude-kill (interactive)
+
+set -euo pipefail
+
+kill_session() {
+    local session="$1"
+    read -rp "Kill session '$session'? [y/N] " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        tmux kill-session -t "=$session"
+        echo "Killed session '$session'."
+    else
+        echo "Cancelled."
+    fi
+}
+
+# --all: kill every session with confirmation
+if [[ "${1:-}" == "--all" ]]; then
+    if ! tmux list-sessions 2>/dev/null | grep -q .; then
+        echo "No tmux sessions running."
+        exit 0
+    fi
+
+    count=$(tmux list-sessions 2>/dev/null | wc -l | tr -d ' ')
+    read -rp "Kill all $count tmux session(s)? [y/N] " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        tmux kill-server
+        echo "Killed all sessions."
+    else
+        echo "Cancelled."
+    fi
+    exit 0
+fi
+
+# Named session: tclaude-kill <name>
+if [[ $# -ge 1 ]]; then
+    session="$1"
+    if ! tmux has-session -t "=$session" 2>/dev/null; then
+        echo "Session '$session' not found."
+        exit 1
+    fi
+    kill_session "$session"
+    exit 0
+fi
+
+# Interactive mode: no args
+if ! tmux list-sessions 2>/dev/null | grep -q .; then
+    echo "No tmux sessions running."
+    exit 0
+fi
+
+# Collect sessions into arrays (same format as tclaude-list)
+NAMES=()
+LINES=()
+
+while IFS='|' read -r name attached windows created; do
+    if [[ "$attached" -gt 0 ]]; then
+        status="attached"
+    else
+        status="detached"
+    fi
+    created_time=$(date -r "$created" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+    NAMES+=("$name")
+    LINES+=("$(printf "%-25s %-12s %-10s %s" "$name" "$status" "$windows" "$created_time")")
+done < <(tmux list-sessions -F '#{session_name}|#{session_attached}|#{session_windows}|#{session_created}' 2>/dev/null)
+
+echo "Claude Code Sessions"
+echo "===================="
+printf "  %-4s %-25s %-12s %-10s %s\n" "#" "SESSION" "STATUS" "WINDOWS" "CREATED"
+echo "  ----------------------------------------------------------------"
+
+for i in "${!LINES[@]}"; do
+    printf "  %-4s %s\n" "$((i + 1))" "${LINES[$i]}"
+done
+
+echo ""
+read -rp "Select session to kill [1-${#NAMES[@]}] (q to quit): " choice
+
+if [[ "$choice" == "q" || -z "$choice" ]]; then
+    exit 0
+fi
+
+if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#NAMES[@]} )); then
+    echo "Invalid selection."
+    exit 1
+fi
+
+SESSION="${NAMES[$((choice - 1))]}"
+kill_session "$SESSION"

--- a/install.sh
+++ b/install.sh
@@ -13,11 +13,11 @@ echo ""
 # 1. Install bin scripts
 echo "Installing scripts to $BIN_DIR..."
 mkdir -p "$BIN_DIR"
-for script in tclaude tclaude-list tclaude-setup; do
+for script in tclaude tclaude-list tclaude-setup tclaude-kill; do
     cp "$SCRIPT_DIR/bin/$script" "$BIN_DIR/$script"
     chmod +x "$BIN_DIR/$script"
 done
-echo "  Installed: tclaude, tclaude-list, tclaude-setup"
+echo "  Installed: tclaude, tclaude-list, tclaude-setup, tclaude-kill"
 
 # 2. Install notification hook
 echo "Installing notification hook to $HOOKS_DIR..."


### PR DESCRIPTION
## Summary
- Add `tclaude-kill` command to kill tmux sessions by name, interactively, or all at once (`--all`)
- Reuses the same table format as `tclaude-list` for interactive mode
- Update `install.sh` to include `tclaude-kill`

Closes #1

## Test plan
- [ ] `tclaude-kill` with no sessions → "No tmux sessions running."
- [ ] `tclaude-kill nonexistent` → "Session 'nonexistent' not found." (exit 1)
- [ ] `tclaude-kill <name>` with a real session → confirms and kills
- [ ] `tclaude-kill` interactive mode → displays table, select to kill
- [ ] `tclaude-kill --all` → confirms and kills all sessions
- [ ] Run `install.sh` and verify `tclaude-kill` is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)