### PR TITLE
feat: add --list flag to tclaude

### DIFF
--- a/bin/tclaude
+++ b/bin/tclaude
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # tclaude - Launch Claude Code in a named tmux session
 # Session name is derived from the current directory basename
-# Usage: tclaude [session-name]
+# Usage: tclaude [--list|-l] [session-name]
 
 set -euo pipefail
+
+# Handle flags
+case "${1:-}" in
+    --list|-l)
+        exec tclaude-list
+        ;;
+esac
 
 # Derive session name from current directory or use provided name
 if [[ $# -ge 1 ]]; then


### PR DESCRIPTION
## Summary
- Add `--list` / `-l` flag to `tclaude` as a shortcut to `tclaude-list`
- Users only need to remember one command

Closes #2

## Test plan
- [ ] `tclaude --list` launches interactive session list
- [ ] `tclaude -l` same behavior
- [ ] `tclaude` (no args) still launches a session as before
- [ ] `tclaude myname` still works for explicit naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)