### PR TITLE
feat: auto-name sessions from git remote

### DIFF
--- a/bin/tclaude
+++ b/bin/tclaude
@@ -9,7 +9,21 @@ set -euo pipefail
 if [[ $# -ge 1 ]]; then
     SESSION_NAME="$1"
 else
-    SESSION_NAME="$(basename "$PWD")"
+    # Try to derive name from git remote (org/repo format)
+    if git rev-parse --is-inside-work-tree &>/dev/null; then
+        remote_url=$(git remote get-url origin 2>/dev/null || true)
+        if [[ -n "$remote_url" ]]; then
+            # Extract org/repo from SSH or HTTPS URLs
+            # git@github.com:BoutLabs/tclaude.git → BoutLabs/tclaude
+            # https://github.com/BoutLabs/tclaude.git → BoutLabs/tclaude
+            org_repo=$(echo "$remote_url" | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+            SESSION_NAME="${org_repo//\//-}"
+        else
+            SESSION_NAME="$(basename "$PWD")"
+        fi
+    else
+        SESSION_NAME="$(basename "$PWD")"
+    fi
 fi
 
 # tmux doesn't allow dots in session names


### PR DESCRIPTION
## Summary
- Derive session names from git remote org/repo (e.g., `BoutLabs-tclaude`) to avoid name collisions
- Falls back to `basename $PWD` when not in a git repo or no remote configured
- Explicit `tclaude <name>` override still works

Closes #5

## Test plan
- [ ] `tclaude` in a git repo with remote → session named `org-repo`
- [ ] `tclaude` in a non-git directory → session named from basename
- [ ] `tclaude myname` → session named `myname` (override)
- [ ] Git repo with no remote → falls back to basename

🤖 Generated with [Claude Code](https://claude.com/claude-code)