### PR TITLE
feat: add tclaude-all for cross-session commands

### DIFF
--- a/bin/tclaude-all
+++ b/bin/tclaude-all
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# tclaude-all - Send a command to all tmux sessions
+# Usage: tclaude-all <command>
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: tclaude-all <command>"
+    echo "Sends keystrokes to all running tmux sessions."
+    exit 1
+fi
+
+COMMAND="$*"
+
+if ! tmux list-sessions 2>/dev/null | grep -q .; then
+    echo "No tmux sessions running."
+    exit 0
+fi
+
+SESSIONS=()
+while IFS= read -r name; do
+    SESSIONS+=("$name")
+done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null)
+
+for session in "${SESSIONS[@]}"; do
+    tmux send-keys -t "=$session" "$COMMAND" Enter
+    echo "Sent to '$session'"
+done
+
+echo ""
+echo "Command sent to ${#SESSIONS[@]} session(s)."

--- a/install.sh
+++ b/install.sh
@@ -13,11 +13,11 @@ echo ""
 # 1. Install bin scripts
 echo "Installing scripts to $BIN_DIR..."
 mkdir -p "$BIN_DIR"
-for script in tclaude tclaude-list tclaude-setup tclaude-kill; do
+for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all; do
     cp "$SCRIPT_DIR/bin/$script" "$BIN_DIR/$script"
     chmod +x "$BIN_DIR/$script"
 done
-echo "  Installed: tclaude, tclaude-list, tclaude-setup, tclaude-kill"
+echo "  Installed: tclaude, tclaude-list, tclaude-setup, tclaude-kill, tclaude-all"
 
 # 2. Install notification hook
 echo "Installing notification hook to $HOOKS_DIR..."


### PR DESCRIPTION
## Summary
- Add `tclaude-all` command that sends keystrokes to all running tmux sessions
- Shows which sessions received the command
- Useful for checking status across sessions (e.g., `tclaude-all /status`)

Closes #3

## Test plan
- [ ] `tclaude-all` with no args shows usage
- [ ] `tclaude-all /status` sends to all sessions
- [ ] No sessions running → "No tmux sessions running."

🤖 Generated with [Claude Code](https://claude.com/claude-code)