### PR TITLE
feat: add uninstall script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# uninstall.sh - Remove all tclaude files
+set -euo pipefail
+
+BIN_DIR="$HOME/.local/bin"
+HOOKS_DIR="$HOME/.claude/hooks"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+CONFIG_DIR="$HOME/.config/tclaude"
+
+echo "=== tclaude uninstaller ==="
+echo ""
+
+# 1. Remove bin scripts
+echo "Removing scripts from $BIN_DIR..."
+for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all; do
+    if [[ -f "$BIN_DIR/$script" ]]; then
+        rm "$BIN_DIR/$script"
+        echo "  Removed: $script"
+    fi
+done
+
+# 2. Remove notification hook
+echo "Removing notification hook from $HOOKS_DIR..."
+if [[ -f "$HOOKS_DIR/notify-telegram.sh" ]]; then
+    rm "$HOOKS_DIR/notify-telegram.sh"
+    echo "  Removed: notify-telegram.sh"
+else
+    echo "  Not found, skipping."
+fi
+
+# 3. Remove hook entry from settings.json
+if [[ -f "$SETTINGS_FILE" ]] && command -v python3 &>/dev/null; then
+    echo "Removing Notification hook from settings.json..."
+    python3 -c "
+import json
+
+with open('$SETTINGS_FILE', 'r') as f:
+    settings = json.load(f)
+
+hooks = settings.get('hooks', {})
+notification = hooks.get('Notification', [])
+
+hook_cmd = '~/.claude/hooks/notify-telegram.sh'
+notification = [h for h in notification if h.get('command') != hook_cmd]
+
+if notification:
+    hooks['Notification'] = notification
+else:
+    hooks.pop('Notification', None)
+
+if not hooks:
+    settings.pop('hooks', None)
+
+with open('$SETTINGS_FILE', 'w') as f:
+    json.dump(settings, f, indent=2)
+    f.write('\n')
+
+print('  Removed Notification hook from settings.json')
+"
+fi
+
+# 4. Optionally remove config directory
+if [[ -d "$CONFIG_DIR" ]]; then
+    echo ""
+    read -rp "Remove Telegram config at $CONFIG_DIR? [y/N] " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        rm -rf "$CONFIG_DIR"
+        echo "  Removed: $CONFIG_DIR"
+    else
+        echo "  Kept: $CONFIG_DIR"
+    fi
+fi
+
+echo ""
+echo "Uninstall complete!"


### PR DESCRIPTION
## Summary
- Add `uninstall.sh` to cleanly remove all installed tclaude files
- Removes bin scripts, notification hook, and settings.json entry
- Prompts before removing Telegram config directory (contains user data)

Closes #6

## Test plan
- [ ] `bash uninstall.sh` removes scripts from `~/.local/bin/`
- [ ] Removes `notify-telegram.sh` from `~/.claude/hooks/`
- [ ] Removes Notification hook from `settings.json` without breaking other settings
- [ ] Prompts before removing `~/.config/tclaude/`
- [ ] Graceful handling when files don't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)