### PR TITLE
feat: auto-log session output

### DIFF
--- a/bin/tclaude
+++ b/bin/tclaude
@@ -42,5 +42,21 @@ if tmux has-session -t "=$SESSION_NAME" 2>/dev/null; then
     exec tmux attach-session -t "=$SESSION_NAME"
 fi
 
-# Create new session and launch claude
-exec tmux new-session -s "$SESSION_NAME" -c "$PWD" "claude"
+# Set up logging
+LOG_DIR="$HOME/.local/share/tclaude/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SESSION_NAME}-$(date +%Y%m%d-%H%M%S).log"
+
+# Rotate logs: keep last 10 per session
+existing_logs=$(ls -1t "$LOG_DIR/${SESSION_NAME}"-*.log 2>/dev/null || true)
+if [[ -n "$existing_logs" ]]; then
+    echo "$existing_logs" | tail -n +10 | while read -r old_log; do
+        rm -f "$old_log"
+    done
+fi
+
+# Create new session, enable pipe-pane for logging, then launch claude
+tmux new-session -d -s "$SESSION_NAME" -c "$PWD"
+tmux pipe-pane -t "=$SESSION_NAME" -o "cat >> '$LOG_FILE'"
+tmux send-keys -t "=$SESSION_NAME" "claude" Enter
+exec tmux attach-session -t "=$SESSION_NAME"

--- a/bin/tclaude-log
+++ b/bin/tclaude-log
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tclaude-log - View session logs
+# Usage: tclaude-log [session-name]
+
+set -euo pipefail
+
+LOG_DIR="$HOME/.local/share/tclaude/logs"
+
+if [[ ! -d "$LOG_DIR" ]]; then
+    echo "No logs found. Start a session with 'tclaude' first."
+    exit 0
+fi
+
+# If session name provided, show its latest log
+if [[ $# -ge 1 ]]; then
+    session="$1"
+    latest=$(ls -1t "$LOG_DIR/${session}"-*.log 2>/dev/null | head -1)
+    if [[ -z "$latest" ]]; then
+        echo "No logs found for session '$session'."
+        exit 1
+    fi
+    echo "Log: $latest"
+    echo "---"
+    exec tail -f "$latest"
+fi
+
+# No args: list available logs grouped by session
+echo "Available session logs:"
+echo "======================="
+echo ""
+
+declare -A seen
+for log in $(ls -1t "$LOG_DIR"/*.log 2>/dev/null); do
+    filename=$(basename "$log")
+    # Strip timestamp suffix to get session name
+    session="${filename%-[0-9]*-[0-9]*.log}"
+    if [[ -z "${seen[$session]:-}" ]]; then
+        seen[$session]=1
+        count=$(ls -1 "$LOG_DIR/${session}"-*.log 2>/dev/null | wc -l | tr -d ' ')
+        latest=$(ls -1t "$LOG_DIR/${session}"-*.log 2>/dev/null | head -1)
+        latest_time=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$latest" 2>/dev/null || echo "unknown")
+        printf "  %-30s %s logs, latest: %s\n" "$session" "$count" "$latest_time"
+    fi
+done
+
+echo ""
+echo "Usage: tclaude-log <session-name> to tail the latest log"

--- a/install.sh
+++ b/install.sh
@@ -13,11 +13,11 @@ echo ""
 # 1. Install bin scripts
 echo "Installing scripts to $BIN_DIR..."
 mkdir -p "$BIN_DIR"
-for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all; do
+for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all tclaude-log; do
     cp "$SCRIPT_DIR/bin/$script" "$BIN_DIR/$script"
     chmod +x "$BIN_DIR/$script"
 done
-echo "  Installed: tclaude, tclaude-list, tclaude-setup, tclaude-kill, tclaude-all"
+echo "  Installed: tclaude, tclaude-list, tclaude-setup, tclaude-kill, tclaude-all, tclaude-log"
 
 # 2. Install notification hook
 echo "Installing notification hook to $HOOKS_DIR..."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,7 +12,7 @@ echo ""
 
 # 1. Remove bin scripts
 echo "Removing scripts from $BIN_DIR..."
-for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all; do
+for script in tclaude tclaude-list tclaude-setup tclaude-kill tclaude-all tclaude-log; do
     if [[ -f "$BIN_DIR/$script" ]]; then
         rm "$BIN_DIR/$script"
         echo "  Removed: $script"


### PR DESCRIPTION
## Summary
- Auto-log tmux session output to `~/.local/share/tclaude/logs/` using `tmux pipe-pane`
- Keep max 10 log files per session name, rotate on new session start
- Add `tclaude-log` command to list and tail session logs

Closes #4

## Test plan
- [ ] Start a session → log file created in `~/.local/share/tclaude/logs/`
- [ ] `tclaude-log` lists available session logs
- [ ] `tclaude-log <session>` tails the latest log
- [ ] Starting 11+ sessions rotates old logs
- [ ] `install.sh` installs `tclaude-log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)